### PR TITLE
Add NukeMail to Temporary Email Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 - [FakeMail](https://www.fakemail.net) - Free; Storage: 2 weeks.
 - [Maildrop](https://maildrop.cc) - Free. 
 - [Inboxkitten](https://inboxkitten.com) - Free; Storage: for 3 hours.
+- [NukeMail](https://nukemail.app) - Free/paid; Storage: 24 hours (free), unlimited (paid); Features: **custom usernames**, multiple domains, **access code for inbox recovery from any device**, no tracking.
+
 
 ### Open Source Software
 


### PR DESCRIPTION
Adding NukeMail (https://nukemail.app) — a receive-only disposable email service.

- Custom username and domain selection (9 domains)
- Access code for inbox recovery from any device (no account needed)
- 24-hour free inbox, unlimited with one-time premium payment
- Real-time email delivery
- No tracking, no cookies

Happy to adjust the formatting if needed.
